### PR TITLE
Integrable into other apps

### DIFF
--- a/src/main/java/org/minifx/fxcommons/MiniFxSceneBuilder.java
+++ b/src/main/java/org/minifx/fxcommons/MiniFxSceneBuilder.java
@@ -63,7 +63,11 @@ public final class MiniFxSceneBuilder {
         } else {
             scene = new Scene(rootNode);
         }
+        applyStylesTo(scene);
+        return scene;
+    }
 
+    public void applyStylesTo(Scene scene) {
         if (useMinifxStyle) {
             scene.getStylesheets().addAll(CSS_LOCATIONS);
         }
@@ -71,7 +75,5 @@ public final class MiniFxSceneBuilder {
         if (additionalCss != null && !additionalCss.isEmpty()) {
             scene.getStylesheets().addAll(additionalCss);
         }
-
-        return scene;
     }
 }

--- a/src/main/java/org/minifx/fxcommons/MiniFxSceneBuilder.java
+++ b/src/main/java/org/minifx/fxcommons/MiniFxSceneBuilder.java
@@ -9,6 +9,10 @@ import static org.minifx.workbench.css.MiniFxCssConstants.CSS_LOCATIONS;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -68,12 +72,20 @@ public final class MiniFxSceneBuilder {
     }
 
     public void applyStylesTo(Scene scene) {
+        scene.getStylesheets().addAll(cssLocations());
+    }
+
+    public List<String> cssLocations() {
+        Builder<String> builder = ImmutableList.builder();
         if (useMinifxStyle) {
-            scene.getStylesheets().addAll(CSS_LOCATIONS);
+            builder.addAll(CSS_LOCATIONS);
         }
 
         if (additionalCss != null && !additionalCss.isEmpty()) {
-            scene.getStylesheets().addAll(additionalCss);
+            builder.addAll(additionalCss);
         }
+
+        return builder.build();
     }
+
 }

--- a/src/main/java/org/minifx/fxcommons/MiniFxUtilityDialogBuilder.java
+++ b/src/main/java/org/minifx/fxcommons/MiniFxUtilityDialogBuilder.java
@@ -4,15 +4,15 @@
 
 package org.minifx.fxcommons;
 
+import static org.minifx.fxcommons.MiniFxSceneBuilder.miniFxSceneBuilder;
+
+import java.util.Collection;
+
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
-
-import java.util.Collection;
-
-import static org.minifx.fxcommons.MiniFxSceneBuilder.miniFxSceneBuilder;
 
 public final class MiniFxUtilityDialogBuilder {
 

--- a/src/main/java/org/minifx/fxcommons/MiniFxWorkbench.java
+++ b/src/main/java/org/minifx/fxcommons/MiniFxWorkbench.java
@@ -1,5 +1,7 @@
 package org.minifx.fxcommons;
 
+import java.util.List;
+
 import org.minifx.workbench.components.MainPane;
 import org.springframework.context.ApplicationContext;
 
@@ -26,10 +28,10 @@ public class MiniFxWorkbench {
         return sceneBuilder.withRoot(mainPane).build();
     }
 
-    public void applyStylesTo(Scene scene) {
-        sceneBuilder.applyStylesTo(scene);
+    public List<String> cssLocations() {
+        return sceneBuilder.cssLocations();
     }
-
+    
     public ApplicationContext springContext() {
         return springContext;
     }

--- a/src/main/java/org/minifx/fxcommons/MiniFxWorkbench.java
+++ b/src/main/java/org/minifx/fxcommons/MiniFxWorkbench.java
@@ -1,0 +1,37 @@
+package org.minifx.fxcommons;
+
+import org.minifx.workbench.components.MainPane;
+import org.springframework.context.ApplicationContext;
+
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+
+public class MiniFxWorkbench {
+
+    private final MiniFxSceneBuilder sceneBuilder;
+    private final MainPane mainPane;
+    private final ApplicationContext springContext;
+
+    public MiniFxWorkbench(MiniFxSceneBuilder sceneBuilder, MainPane mainPane, ApplicationContext springContext) {
+        this.sceneBuilder = sceneBuilder;
+        this.mainPane = mainPane;
+        this.springContext = springContext;
+    }
+
+    public Parent mainPane() {
+        return mainPane;
+    }
+
+    public Scene createScene() {
+        return sceneBuilder.withRoot(mainPane).build();
+    }
+
+    public void applyStylesTo(Scene scene) {
+        sceneBuilder.applyStylesTo(scene);
+    }
+
+    public ApplicationContext springContext() {
+        return springContext;
+    }
+
+}

--- a/src/main/java/org/minifx/fxcommons/service/AgingService.java
+++ b/src/main/java/org/minifx/fxcommons/service/AgingService.java
@@ -1,14 +1,15 @@
 package org.minifx.fxcommons.service;
 
-import javafx.concurrent.Service;
-import javafx.concurrent.Task;
-import org.apache.commons.lang3.time.DurationFormatUtils;
-
-import java.time.Instant;
-
 import static java.lang.String.format;
 import static java.time.Duration.between;
 import static java.time.Instant.now;
+
+import java.time.Instant;
+
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+import javafx.concurrent.Service;
+import javafx.concurrent.Task;
 
 public final class AgingService extends Service<Void> {
     private static final int DEFAULT_AGING_INTERVAL = 1000;

--- a/src/main/java/org/minifx/fxcommons/util/ChangeListeners.java
+++ b/src/main/java/org/minifx/fxcommons/util/ChangeListeners.java
@@ -1,8 +1,8 @@
 package org.minifx.fxcommons.util;
 
-import javafx.beans.value.ChangeListener;
-
 import java.util.function.Consumer;
+
+import javafx.beans.value.ChangeListener;
 
 public final class ChangeListeners {
 

--- a/src/main/java/org/minifx/workbench/MiniFx.java
+++ b/src/main/java/org/minifx/workbench/MiniFx.java
@@ -8,9 +8,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.minifx.fxcommons.MiniFxWorkbench;
 import org.minifx.fxcommons.SingleSceneSpringJavaFxApplication;
 import org.minifx.fxcommons.SingleSceneSpringJavaFxApplication.FxLauncher;
 import org.minifx.workbench.conf.MiniFxWorkbenchConfiguration;
+import org.minifx.workbench.conf.MiniFxWorkbenchSceneConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class MiniFx {
 
@@ -26,14 +29,29 @@ public class MiniFx {
      * @return the launcher
      */
     public static FxLauncher launcher(Class<?>... configurationClasses) {
-        return SingleSceneSpringJavaFxApplication.applicationLauncher()
-                .configurationClasses(ensureMiniFxConfigIsContainedAndLast(configurationClasses));
+        return SingleSceneSpringJavaFxApplication.applicationLauncher().configurationClasses(
+                ensureContainedAndLast(MiniFxWorkbenchSceneConfiguration.class, configurationClasses));
     }
 
-    private static final Class<?>[] ensureMiniFxConfigIsContainedAndLast(Class<?>... configurationClasses) {
+    /**
+     * Loads the minifx workbench from the given configuration classes, ensuring that the minifx configurations, which
+     * do the magic are contained at the right place (last in the list).
+     * NOTE: this must be called from the fx-thread!
+     * 
+     * @param configurationClasses the configuration classes to load
+     * @return a {@link MiniFxWorkbench} object, containing all the configured views etc, ready to be plugged into
+     *         another application.
+     */
+    public static MiniFxWorkbench loadFrom(Class<?>... configurationClasses) {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
+                ensureContainedAndLast(MiniFxWorkbenchConfiguration.class, configurationClasses));
+        return ctx.getBean(MiniFxWorkbench.class);
+    }
+
+    private static final Class<?>[] ensureContainedAndLast(Class<?> confToPutLast, Class<?>[] configurationClasses) {
         List<Class<?>> classes = new ArrayList<>(Arrays.asList(configurationClasses));
-        classes.remove(MiniFxWorkbenchConfiguration.class);
-        classes.add(MiniFxWorkbenchConfiguration.class);
+        classes.remove(confToPutLast);
+        classes.add(confToPutLast);
         return classes.toArray(new Class<?>[classes.size()]);
     }
 }

--- a/src/main/java/org/minifx/workbench/annotations/Icon.java
+++ b/src/main/java/org/minifx/workbench/annotations/Icon.java
@@ -4,14 +4,15 @@
 
 package org.minifx.workbench.annotations;
 
-import javafx.scene.paint.Color;
-import org.controlsfx.glyphfont.FontAwesome;
-import org.minifx.workbench.domain.Perspective;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.controlsfx.glyphfont.FontAwesome;
+import org.minifx.workbench.domain.Perspective;
+
+import javafx.scene.paint.Color;
 
 /**
  * Annotation for specifying the Icon of a MiniFx view or {@link Perspective}. NOTE: the {@link #color()} String must

--- a/src/main/java/org/minifx/workbench/components/MainPane.java
+++ b/src/main/java/org/minifx/workbench/components/MainPane.java
@@ -4,28 +4,13 @@
 
 package org.minifx.workbench.components;
 
-import javafx.application.Platform;
-import javafx.geometry.Pos;
-import javafx.scene.Node;
-import javafx.scene.control.MenuBar;
-import javafx.scene.control.ToggleButton;
-import javafx.scene.control.ToggleGroup;
-import javafx.scene.control.ToolBar;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
-import org.minifx.workbench.css.MiniFxCssConstants;
-import org.minifx.workbench.domain.definition.DisplayProperties;
-import org.minifx.workbench.domain.definition.FooterDefinition;
-import org.minifx.workbench.domain.definition.PerspectiveDefinition;
-import org.minifx.workbench.nodes.FxNodeFactory;
-import org.minifx.workbench.spring.AbstractPerspectiveEvent;
-import org.minifx.workbench.spring.ActivatePerspectiveCommand;
-import org.minifx.workbench.spring.ChangePerspectiveButtonStyleCommand;
-import org.minifx.workbench.spring.PerspectiveActivatedEvent;
-import org.minifx.workbench.util.MiniFxComponents;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.event.EventListener;
+import static java.util.Collections.singletonList;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+import static org.minifx.workbench.css.MiniFxCssConstants.PERSPECTIVE_BUTTON_CLASS;
+import static org.minifx.workbench.css.MiniFxCssConstants.TOOLBAR_BUTTON_CLASS;
+import static org.minifx.workbench.util.MiniFxComponents.containerPaneFrom;
+import static org.minifx.workbench.util.MiniFxComponents.createPerspective;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -35,12 +20,28 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static com.google.common.collect.ImmutableList.copyOf;
-import static java.util.Collections.singletonList;
-import static org.minifx.workbench.css.MiniFxCssConstants.PERSPECTIVE_BUTTON_CLASS;
-import static org.minifx.workbench.css.MiniFxCssConstants.TOOLBAR_BUTTON_CLASS;
-import static org.minifx.workbench.util.MiniFxComponents.containerPaneFrom;
-import static org.minifx.workbench.util.MiniFxComponents.createPerspective;
+import org.minifx.workbench.css.MiniFxCssConstants;
+import org.minifx.workbench.domain.definition.DisplayProperties;
+import org.minifx.workbench.domain.definition.FooterDefinition;
+import org.minifx.workbench.domain.definition.PerspectiveDefinition;
+import org.minifx.workbench.domain.definition.ToolbarItemDefinition;
+import org.minifx.workbench.spring.AbstractPerspectiveEvent;
+import org.minifx.workbench.spring.ActivatePerspectiveCommand;
+import org.minifx.workbench.spring.ChangePerspectiveButtonStyleCommand;
+import org.minifx.workbench.spring.PerspectiveActivatedEvent;
+import org.minifx.workbench.util.MiniFxComponents;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+
+import javafx.application.Platform;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.ToolBar;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 
 /**
  * Main JavaFX Pane for a MiniFx application. It has a toolbar for perspective switching at the top. The active
@@ -57,14 +58,16 @@ public class MainPane extends BorderPane {
     private HBox perspectiveButtonsBox;
     private ToggleGroup perspectiveButtonToggleGroup = new ToggleGroup();
 
-    public MainPane(Iterable<Object> toolbarItems, ApplicationEventPublisher publisher, FxNodeFactory fxNodeFactory) {
-        this(toolbarItems, DEFAULT_FILLER, publisher, fxNodeFactory);
+    public MainPane(Collection<ToolbarItemDefinition> toolbarItems, ApplicationEventPublisher publisher) {
+        this(toolbarItems, DEFAULT_FILLER, publisher);
     }
 
-    public MainPane(Iterable<Object> toolbarItems, Node filler, ApplicationEventPublisher publisher,
-            FxNodeFactory fxNodeFactory) {
+    public MainPane(Collection<ToolbarItemDefinition> toolbarItems, Node filler, ApplicationEventPublisher publisher) {
         this.publisher = publisher;
-        List<Node> toolbarNodes = fxNodeFactory.fxNodesFrom(copyOf(toolbarItems));
+        List<Node> toolbarNodes = toolbarItems.stream()//
+                .sorted(comparing(ToolbarItemDefinition::order))//
+                .map(ToolbarItemDefinition::node)//
+                .collect(toList());
 
         HBox toolbarBox = horizontalBoxOf(Pos.TOP_LEFT);
         HBox centralBox = horizontalBoxOf(Pos.TOP_CENTER);
@@ -88,7 +91,8 @@ public class MainPane extends BorderPane {
             throw new IllegalStateException("Footer already initialized!");
         }
 
-        Platform.runLater(() -> containerPaneFrom(footers).map(MiniFxComponents::configureSingleNodeStyle).ifPresent(this::setBottom));
+        Platform.runLater(() -> containerPaneFrom(footers).map(MiniFxComponents::configureSingleNodeStyle)
+                .ifPresent(this::setBottom));
     }
 
     /**

--- a/src/main/java/org/minifx/workbench/components/MainPane.java
+++ b/src/main/java/org/minifx/workbench/components/MainPane.java
@@ -7,6 +7,7 @@ package org.minifx.workbench.components;
 import javafx.application.Platform;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
+import javafx.scene.control.MenuBar;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.ToolBar;

--- a/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchConfiguration.java
+++ b/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchConfiguration.java
@@ -26,8 +26,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import javafx.scene.control.MenuBar;
-
 @Configuration
 @Import({ FactoryMethodsCollectorConfiguration.class, FxmlNodeServiceConfiguration.class,
         NodeFactoryConfiguration.class, MiniFxWorkbenchInitialization.class })
@@ -59,21 +57,21 @@ public class MiniFxWorkbenchConfiguration {
     }
 
     @Bean
-    public ElementsDefinitionConstructor elementsDefinitionConstructor(
+    public static ElementsDefinitionConstructor elementsDefinitionConstructor(
             WorkbenchElementsRepository factoryMethodsRepository, BeanInformationExtractor beanInformationExtractor,
             FxNodeFactory fxNodeFactory) {
         return new ElementsDefinitionConstructor(factoryMethodsRepository, beanInformationExtractor, fxNodeFactory);
     }
 
     @Bean
-    public BeanInformationExtractor beanInformationExtractor(BeanInformationRepository factoryMethodsRepository) {
+    public static BeanInformationExtractor beanInformationExtractor(BeanInformationRepository factoryMethodsRepository) {
         return new BeanInformationExtractorImpl(factoryMethodsRepository);
     }
 
     @Bean
-    public MainPane mainPane(ApplicationEventPublisher publisher, WorkbenchElementsRepository factoryMethodsRepository,
-            FxNodeFactory fxNodeFactory, @Autowired(required=false) MenuBar menuBar) {
-        MainPane mainPanel = new MainPane(factoryMethodsRepository.toolbarItems(), publisher, fxNodeFactory);
+    public static MainPane mainPane(ApplicationEventPublisher publisher,
+            ElementsDefinitionConstructor elementsDefinitionConstructor) {
+        MainPane mainPanel = new MainPane(elementsDefinitionConstructor.toolbarItems(), publisher);
         mainPanel.setId(ID_MAIN_PANEL);
         return mainPanel;
     }

--- a/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchConfiguration.java
+++ b/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchConfiguration.java
@@ -4,13 +4,15 @@
 
 package org.minifx.workbench.conf;
 
-import javafx.scene.Scene;
+import static java.util.stream.Collectors.toList;
+import static org.minifx.fxcommons.MiniFxSceneBuilder.miniFxSceneBuilder;
+
+import java.util.List;
+
 import org.minifx.fxcommons.MiniFxSceneBuilder;
+import org.minifx.fxcommons.MiniFxWorkbench;
 import org.minifx.workbench.components.MainPane;
-import org.minifx.workbench.domain.definition.FooterDefinition;
-import org.minifx.workbench.domain.definition.PerspectiveDefinition;
 import org.minifx.workbench.nodes.FxNodeFactory;
-import org.minifx.workbench.providers.PerspectiveProvider;
 import org.minifx.workbench.spring.BeanInformationExtractor;
 import org.minifx.workbench.spring.BeanInformationExtractorImpl;
 import org.minifx.workbench.spring.BeanInformationRepository;
@@ -23,20 +25,12 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.context.event.EventListener;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Stream.concat;
-import static org.minifx.fxcommons.MiniFxSceneBuilder.miniFxSceneBuilder;
+import javafx.scene.control.MenuBar;
 
 @Configuration
-@Import({FactoryMethodsCollectorConfiguration.class, FxmlNodeServiceConfiguration.class,
-        NodeFactoryConfiguration.class, MiniFxWorkbenchInitialization.class})
+@Import({ FactoryMethodsCollectorConfiguration.class, FxmlNodeServiceConfiguration.class,
+        NodeFactoryConfiguration.class, MiniFxWorkbenchInitialization.class })
 public class MiniFxWorkbenchConfiguration {
 
     private static final int DEFAULT_HEIGHT = 760;
@@ -52,18 +46,16 @@ public class MiniFxWorkbenchConfiguration {
     private MiniFxSceneBuilder sceneBuilder;
 
     @Bean
-    public Scene mainScene(MainPane mainPane) {
+    public MiniFxWorkbench miniFxContext(MainPane mainPane, ApplicationContext ctx) {
         if (sceneBuilder == null) {
             sceneBuilder = miniFxSceneBuilder().withSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
         }
-
-        sceneBuilder.withRoot(mainPane);
 
         if (cssStyleSheets != null) {
             sceneBuilder.withAdditionalCss(cssStyleSheets.stream().flatMap(List::stream).collect(toList()));
         }
 
-        return sceneBuilder.build();
+        return new MiniFxWorkbench(sceneBuilder, mainPane, ctx);
     }
 
     @Bean
@@ -80,7 +72,7 @@ public class MiniFxWorkbenchConfiguration {
 
     @Bean
     public MainPane mainPane(ApplicationEventPublisher publisher, WorkbenchElementsRepository factoryMethodsRepository,
-            FxNodeFactory fxNodeFactory) {
+            FxNodeFactory fxNodeFactory, @Autowired(required=false) MenuBar menuBar) {
         MainPane mainPanel = new MainPane(factoryMethodsRepository.toolbarItems(), publisher, fxNodeFactory);
         mainPanel.setId(ID_MAIN_PANEL);
         return mainPanel;

--- a/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchInitialization.java
+++ b/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchInitialization.java
@@ -3,6 +3,7 @@ package org.minifx.workbench.conf;
 import org.minifx.workbench.components.MainPane;
 import org.minifx.workbench.domain.definition.FooterDefinition;
 import org.minifx.workbench.domain.definition.PerspectiveDefinition;
+import org.minifx.workbench.domain.definition.ToolbarItemDefinition;
 import org.minifx.workbench.providers.PerspectiveProvider;
 import org.minifx.workbench.spring.ActivatePerspectiveCommand;
 import org.minifx.workbench.spring.ElementsDefinitionConstructor;
@@ -42,6 +43,10 @@ public class MiniFxWorkbenchInitialization {
     private static Collection<FooterDefinition> allFooters(ApplicationContext ctx) {
         return ctx.getBean(ElementsDefinitionConstructor.class).footers();
     }
+
+//    private static Collection<ToolbarItemDefinition> allToolbarItems(ApplicationContext ctx) {
+//        return ctx.getBean(ElementsDefinitionConstructor.class).toolbarItems();
+//    }
 
     private static List<PerspectiveDefinition> allPerspectives(ApplicationContext ctx) {
         ElementsDefinitionConstructor instantiator = ctx.getBean(ElementsDefinitionConstructor.class);

--- a/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchInitialization.java
+++ b/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchInitialization.java
@@ -1,9 +1,16 @@
 package org.minifx.workbench.conf;
 
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
 import org.minifx.workbench.components.MainPane;
 import org.minifx.workbench.domain.definition.FooterDefinition;
 import org.minifx.workbench.domain.definition.PerspectiveDefinition;
-import org.minifx.workbench.domain.definition.ToolbarItemDefinition;
 import org.minifx.workbench.providers.PerspectiveProvider;
 import org.minifx.workbench.spring.ActivatePerspectiveCommand;
 import org.minifx.workbench.spring.ElementsDefinitionConstructor;
@@ -11,14 +18,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Stream.concat;
 
 @Configuration
 public class MiniFxWorkbenchInitialization {

--- a/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchSceneConfiguration.java
+++ b/src/main/java/org/minifx/workbench/conf/MiniFxWorkbenchSceneConfiguration.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.minifx.workbench.conf;
+
+import org.minifx.fxcommons.MiniFxWorkbench;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import javafx.scene.Scene;
+
+@Configuration
+@Import({ MiniFxWorkbenchConfiguration.class })
+public class MiniFxWorkbenchSceneConfiguration {
+
+    @Bean
+    public Scene mainScene(MiniFxWorkbench workbench) {
+        return workbench.createScene();
+    }
+
+}

--- a/src/main/java/org/minifx/workbench/css/MiniFxCssConstants.java
+++ b/src/main/java/org/minifx/workbench/css/MiniFxCssConstants.java
@@ -4,13 +4,13 @@
 
 package org.minifx.workbench.css;
 
-import com.google.common.annotations.VisibleForTesting;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 
 import java.util.Collection;
 import java.util.List;
 
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
+import com.google.common.annotations.VisibleForTesting;
 
 public final class MiniFxCssConstants {
 

--- a/src/main/java/org/minifx/workbench/domain/DefaultPerspective.java
+++ b/src/main/java/org/minifx/workbench/domain/DefaultPerspective.java
@@ -4,10 +4,10 @@
 
 package org.minifx.workbench.domain;
 
+import static org.controlsfx.glyphfont.FontAwesome.Glyph.RANDOM;
+
 import org.minifx.workbench.annotations.Icon;
 import org.minifx.workbench.annotations.Name;
-
-import static org.controlsfx.glyphfont.FontAwesome.Glyph.RANDOM;
 
 @Name("Default perspective")
 @Icon(RANDOM)

--- a/src/main/java/org/minifx/workbench/domain/definition/DisplayProperties.java
+++ b/src/main/java/org/minifx/workbench/domain/definition/DisplayProperties.java
@@ -4,12 +4,12 @@
 
 package org.minifx.workbench.domain.definition;
 
-import javafx.scene.Node;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.util.Objects.requireNonNull;
+import javafx.scene.Node;
 
 /**
  * @author kfuchsbe

--- a/src/main/java/org/minifx/workbench/domain/definition/ToolbarItemDefinition.java
+++ b/src/main/java/org/minifx/workbench/domain/definition/ToolbarItemDefinition.java
@@ -1,0 +1,50 @@
+package org.minifx.workbench.domain.definition;
+
+import java.util.Objects;
+
+import javafx.scene.Node;
+
+public class ToolbarItemDefinition {
+
+    private final Node node;
+    private final int order;
+
+    public ToolbarItemDefinition(Node node, int order) {
+        this.node = node;
+        this.order = order;
+    }
+
+    public Node node() {
+        return node;
+    }
+
+    public int order() {
+        return order;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(node, order);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ToolbarItemDefinition other = (ToolbarItemDefinition) obj;
+        return Objects.equals(node, other.node) && order == other.order;
+    }
+
+    @Override
+    public String toString() {
+        return "ToolbarItemDefinition [node=" + node + ", order=" + order + "]";
+    }
+
+}

--- a/src/main/java/org/minifx/workbench/spring/BeanInformationExtractor.java
+++ b/src/main/java/org/minifx/workbench/spring/BeanInformationExtractor.java
@@ -20,4 +20,6 @@ public interface BeanInformationExtractor {
      */
     Color iconColor(Object view);
 
+    int orderFrom(Object view);
+
 }

--- a/src/main/java/org/minifx/workbench/spring/BeanInformationExtractorImpl.java
+++ b/src/main/java/org/minifx/workbench/spring/BeanInformationExtractorImpl.java
@@ -4,8 +4,12 @@
 
 package org.minifx.workbench.spring;
 
-import javafx.scene.Node;
-import javafx.scene.paint.Color;
+import static java.util.Objects.requireNonNull;
+import static org.minifx.workbench.util.Names.nameFromNameMethod;
+import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
+
+import java.util.Optional;
+
 import org.minifx.workbench.annotations.Icon;
 import org.minifx.workbench.annotations.Name;
 import org.minifx.workbench.annotations.NoGutters;
@@ -16,11 +20,8 @@ import org.minifx.workbench.util.Perspectives;
 import org.minifx.workbench.util.Purpose;
 import org.springframework.core.annotation.Order;
 
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static org.minifx.workbench.util.Names.nameFromNameMethod;
-import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
+import javafx.scene.Node;
+import javafx.scene.paint.Color;
 
 public class BeanInformationExtractorImpl implements BeanInformationExtractor {
 

--- a/src/main/java/org/minifx/workbench/spring/BeanInformationExtractorImpl.java
+++ b/src/main/java/org/minifx/workbench/spring/BeanInformationExtractorImpl.java
@@ -32,7 +32,7 @@ public class BeanInformationExtractorImpl implements BeanInformationExtractor {
 
     @Override
     public DisplayProperties displayPropertiesFrom(Object view, Purpose purpose) {
-        return new DisplayProperties(viewNameFrom(view), graphicsFor(view, purpose).orElse(null), viewOrderFrom(view), hasGutters(view));
+        return new DisplayProperties(viewNameFrom(view), graphicsFor(view, purpose).orElse(null), orderFrom(view), hasGutters(view));
     }
 
     private boolean hasGutters(Object view) {
@@ -65,7 +65,8 @@ public class BeanInformationExtractorImpl implements BeanInformationExtractor {
         return Color.valueOf(color);
     }
 
-    private int viewOrderFrom(Object view) {
+    @Override
+    public int orderFrom(Object view) {
         Optional<Order> order = repository.from(view).getAnnotation(Order.class);
         return order.map(Order::value).orElse(LOWEST_PRECEDENCE);
     }

--- a/src/main/java/org/minifx/workbench/spring/ElementsDefinitionConstructor.java
+++ b/src/main/java/org/minifx/workbench/spring/ElementsDefinitionConstructor.java
@@ -17,6 +17,7 @@ import org.minifx.workbench.domain.PerspectivePos;
 import org.minifx.workbench.domain.definition.DisplayProperties;
 import org.minifx.workbench.domain.definition.FooterDefinition;
 import org.minifx.workbench.domain.definition.PerspectiveDefinition;
+import org.minifx.workbench.domain.definition.ToolbarItemDefinition;
 import org.minifx.workbench.domain.definition.ViewDefinition;
 import org.minifx.workbench.nodes.FxNodeFactory;
 import org.minifx.workbench.util.Names;
@@ -109,6 +110,10 @@ public class ElementsDefinitionConstructor {
         return footerDefinitionsFrom(repository.footers());
     }
 
+    public Set<ToolbarItemDefinition> toolbarItems() {
+        return toolbarItemDefinitionsFrom(repository.toolbarItems());
+    }
+    
     @VisibleForTesting
     PerspectivePos viewPosFor(Object view) {
         requireNonNull(view, "view must not be null");
@@ -164,6 +169,14 @@ public class ElementsDefinitionConstructor {
 
     private Set<FooterDefinition> footerDefinitionsFrom(Collection<Object> allViews) {
         return allViews.stream().map(this::toFooterDefinition).collect(toSet());
+    }
+
+    private Set<ToolbarItemDefinition> toolbarItemDefinitionsFrom(Collection<Object> toolbarItems) {
+        return toolbarItems.stream().map(this::toToolbarItemDefinition).collect(toSet());
+    }
+
+    private ToolbarItemDefinition toToolbarItemDefinition(Object tbItem) {
+        return new ToolbarItemDefinition(fxNodeFactory.fxNodeFrom(tbItem), extractor.orderFrom(tbItem));
     }
 
     private ViewDefinition toViewDefinition(Object view) {

--- a/src/main/java/org/minifx/workbench/spring/ElementsDefinitionConstructor.java
+++ b/src/main/java/org/minifx/workbench/spring/ElementsDefinitionConstructor.java
@@ -4,10 +4,13 @@
 
 package org.minifx.workbench.spring;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableListMultimap.Builder;
-import com.google.common.collect.ListMultimap;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
 import org.minifx.workbench.annotations.Footer;
 import org.minifx.workbench.annotations.Icon;
 import org.minifx.workbench.annotations.Name;
@@ -25,12 +28,10 @@ import org.minifx.workbench.util.Perspectives;
 import org.minifx.workbench.util.Purpose;
 import org.springframework.core.annotation.Order;
 
-import java.util.Collection;
-import java.util.Optional;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toSet;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableListMultimap.Builder;
+import com.google.common.collect.ListMultimap;
 
 /**
  * Contains all the relevant logic to bring together all the information which is required to instantiate the workbench

--- a/src/main/java/org/minifx/workbench/util/Icons.java
+++ b/src/main/java/org/minifx/workbench/util/Icons.java
@@ -4,13 +4,14 @@
 
 package org.minifx.workbench.util;
 
-import javafx.scene.paint.Color;
+import java.util.Optional;
+
 import org.controlsfx.glyphfont.FontAwesome;
 import org.controlsfx.glyphfont.Glyph;
 import org.controlsfx.glyphfont.GlyphFontRegistry;
 import org.minifx.workbench.annotations.Icon;
 
-import java.util.Optional;
+import javafx.scene.paint.Color;
 
 /**
  * Static methods for creating icons

--- a/src/main/java/org/minifx/workbench/util/MiniFxComponents.java
+++ b/src/main/java/org/minifx/workbench/util/MiniFxComponents.java
@@ -4,16 +4,11 @@
 
 package org.minifx.workbench.util;
 
-import com.google.common.collect.Iterables;
-import javafx.scene.Node;
-import javafx.scene.control.Tab;
-import javafx.scene.control.TabPane;
-import javafx.scene.layout.BorderPane;
-import org.minifx.workbench.components.TextWorkbenchView;
-import org.minifx.workbench.domain.PerspectivePos;
-import org.minifx.workbench.domain.definition.PerspectiveDefinition;
-import org.minifx.workbench.domain.definition.TabbableDefinition;
-import org.minifx.workbench.domain.definition.ViewDefinition;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static org.minifx.workbench.css.MiniFxCssConstants.COMPONENTS_OF_MAIN_PANEL_CLASS;
+import static org.minifx.workbench.css.MiniFxCssConstants.COMPONENTS_OF_MAIN_PANEL_CLASS_NO_GUTTERS;
+import static org.minifx.workbench.css.MiniFxCssConstants.SINGLE_COMPONENT_OF_MAIN_PANEL_CLASS;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -24,11 +19,18 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-import static org.minifx.workbench.css.MiniFxCssConstants.COMPONENTS_OF_MAIN_PANEL_CLASS;
-import static org.minifx.workbench.css.MiniFxCssConstants.COMPONENTS_OF_MAIN_PANEL_CLASS_NO_GUTTERS;
-import static org.minifx.workbench.css.MiniFxCssConstants.SINGLE_COMPONENT_OF_MAIN_PANEL_CLASS;
+import org.minifx.workbench.components.TextWorkbenchView;
+import org.minifx.workbench.domain.PerspectivePos;
+import org.minifx.workbench.domain.definition.PerspectiveDefinition;
+import org.minifx.workbench.domain.definition.TabbableDefinition;
+import org.minifx.workbench.domain.definition.ViewDefinition;
+
+import com.google.common.collect.Iterables;
+
+import javafx.scene.Node;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.layout.BorderPane;
 
 public class MiniFxComponents {
 

--- a/src/main/java/org/minifx/workbench/util/Perspectives.java
+++ b/src/main/java/org/minifx/workbench/util/Perspectives.java
@@ -4,8 +4,14 @@
 
 package org.minifx.workbench.util;
 
-import javafx.scene.Node;
-import javafx.scene.paint.Color;
+import static java.util.Objects.requireNonNull;
+import static java.util.Optional.ofNullable;
+import static org.minifx.workbench.domain.PerspectivePos.CENTER;
+import static org.minifx.workbench.util.Purpose.PERSPECTIVE;
+import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
+
+import java.util.Optional;
+
 import org.controlsfx.glyphfont.FontAwesome;
 import org.minifx.workbench.annotations.Icon;
 import org.minifx.workbench.annotations.Name;
@@ -17,13 +23,8 @@ import org.minifx.workbench.domain.definition.DisplayProperties;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.Order;
 
-import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-import static java.util.Optional.ofNullable;
-import static org.minifx.workbench.domain.PerspectivePos.CENTER;
-import static org.minifx.workbench.util.Purpose.PERSPECTIVE;
-import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
+import javafx.scene.Node;
+import javafx.scene.paint.Color;
 
 /**
  * Utility methods for perspective classes.

--- a/src/test/java/org/minifx/workbench/conf/FullyConfiguredExampleTest.java
+++ b/src/test/java/org/minifx/workbench/conf/FullyConfiguredExampleTest.java
@@ -24,7 +24,7 @@ import javafx.scene.control.ToggleButton;
 public class FullyConfiguredExampleTest extends AbstractSpringApplicationTest {
 
     public FullyConfiguredExampleTest() {
-        super(MiniFxWorkbenchConfiguration.class, FullExampleConfiguration.class);
+        super(MiniFxWorkbenchSceneConfiguration.class, FullExampleConfiguration.class);
     }
 
     @Before

--- a/src/test/java/org/minifx/workbench/conf/NoPanelConfiguredExampleTest.java
+++ b/src/test/java/org/minifx/workbench/conf/NoPanelConfiguredExampleTest.java
@@ -16,7 +16,7 @@ import javafx.scene.Node;
 public class NoPanelConfiguredExampleTest extends AbstractSpringApplicationTest {
 
     public NoPanelConfiguredExampleTest() {
-        super(MiniFxWorkbenchConfiguration.class);
+        super(MiniFxWorkbenchSceneConfiguration.class);
     }
 
     @Test

--- a/src/test/java/org/minifx/workbench/examples/simpledemo/DemoMain.java
+++ b/src/test/java/org/minifx/workbench/examples/simpledemo/DemoMain.java
@@ -4,7 +4,7 @@
 
 package org.minifx.workbench.examples.simpledemo;
 
-import org.minifx.workbench.conf.MiniFxWorkbenchConfiguration;
+import org.minifx.workbench.conf.MiniFxWorkbenchSceneConfiguration;
 
 import static org.minifx.fxcommons.SingleSceneSpringJavaFxApplication.applicationLauncher;
 
@@ -12,7 +12,7 @@ public class DemoMain {
 
     public static void main(String[] args) {
         applicationLauncher()
-                .configurationClasses(MiniFxWorkbenchConfiguration.class, DemoSimpleExampleConfiguration.class)
+                .configurationClasses(MiniFxWorkbenchSceneConfiguration.class, DemoSimpleExampleConfiguration.class)
                 .launch(args);
     }
 

--- a/src/test/java/org/minifx/workbench/spring/WorkbenchElementsPostProcessorTest.java
+++ b/src/test/java/org/minifx/workbench/spring/WorkbenchElementsPostProcessorTest.java
@@ -1,0 +1,58 @@
+package org.minifx.workbench.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class WorkbenchElementsPostProcessorTest {
+
+    private WorkbenchElementsPostProcessor pp;
+
+    @Before
+    public void setUp() {
+        AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(ExampleConfig.class);
+        pp = ctx.getBean(WorkbenchElementsPostProcessor.class);
+
+    }
+
+    @Test
+    public void publicIsPresent() {
+        Optional<Method> m = pp.factoryMethodFor("public");
+        assertThat(m.isPresent()).isTrue();
+    }
+
+    @Test
+    public void staticIsPresent() {
+        Optional<Method> m = pp.factoryMethodFor("static");
+        assertThat(m.isPresent()).isTrue();
+    }
+
+    
+    @Configuration
+    public static class ExampleConfig {
+
+        @Bean
+        public static String staticString() {
+            return "static";
+        }
+
+        @Bean
+        public String publicString() {
+            return "public";
+        }
+
+        @Bean
+        public WorkbenchElementsPostProcessor postProcessor() {
+            return new WorkbenchElementsPostProcessor();
+        }
+    }
+}


### PR DESCRIPTION
The purpose of this PR is, to make minifx usable also in apps, which are not launched with the custom launcher.

For this, there is now another static method in MiniFx class, which allows to just load from configuration classes, without creating a dedicated scene. This way, the resulting panel can be plugged into 'classic' applications.